### PR TITLE
add: validate base URL

### DIFF
--- a/api/authlete_api_impl.go
+++ b/api/authlete_api_impl.go
@@ -777,5 +777,6 @@ func (self *impl) Echo(parameters *map[string]string) (res *map[string]string, e
 func New(configuration conf.AuthleteConfiguration) AuthleteApi {
 	im := impl{}
 	im.init(configuration)
+
 	return &im
 }

--- a/api/authlete_api_impl.go
+++ b/api/authlete_api_impl.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	uPath "path"
 	"strconv"
 	"strings"
 
@@ -124,8 +125,12 @@ func (self *impl) buildRequestHeader() http.Header {
 func (self *impl) buildRequestUrl(path string, queryParams map[string]string) *url.URL {
 	var builder strings.Builder
 
-	builder.WriteString(self.baseUrl)
-	builder.WriteString(path)
+	endpoint, err := url.Parse(self.baseUrl)
+	if err != nil {
+		log.Panicf(`Failed to parse a URL from '%v'`, self.baseUrl)
+	}
+	endpoint.Path = uPath.Join(endpoint.Path, path)
+	builder.WriteString(endpoint.String())
 
 	if queryParams != nil {
 		delimiter := `?`

--- a/api/authlete_api_impl.go
+++ b/api/authlete_api_impl.go
@@ -42,7 +42,6 @@ type impl struct {
 }
 
 func (self *impl) init(configuration conf.AuthleteConfiguration) {
-	// validate base URL
 	u, err := url.Parse(configuration.GetBaseUrl())
 	if err != nil {
 		log.Panicf(`Invalid base URL '%s'`, configuration.GetBaseUrl())


### PR DESCRIPTION
I followed the Quick Start guide and encountered an error when calling the `'/api/auth/authorization'` API from Authlete. It returned a `400` status code with the following response body: `<h1>Bad Message 400</h1><pre>reason: Ambiguous URI empty segment</pre>`.

With my current implementation, if I specify the `baseURL` with a trailing slash `/`, it will result in duplicate slashes in the request URL. For example, `https://api.authlete.com//api/auth/authorization`.

It need to use the standard `path` package to properly generate the URL.