### PR TITLE
add Transport field to Settings and configure HTTP client transport

### DIFF
--- a/api/authlete_api_impl.go
+++ b/api/authlete_api_impl.go
@@ -174,7 +174,8 @@ func (self *impl) buildRequestBody(requestBody interface{}) io.ReadCloser {
 
 func (self *impl) prepareClient() *http.Client {
 	return &http.Client{
-		Timeout: self.settings.Timeout,
+		Timeout:   self.settings.Timeout,
+		Transport: self.settings.Transport,
 	}
 }
 

--- a/api/settings.go
+++ b/api/settings.go
@@ -16,9 +16,13 @@
 
 package api
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 type Settings struct {
 	Timeout   time.Duration
 	UserAgent string
+	Transport http.RoundTripper
 }


### PR DESCRIPTION
This change adds a Transport field to the Settings struct, allowing users to configure a custom HTTP transport for the client.

This addition enables the option to implement tracing capabilities for Authlete API calls.

The implementation is based on the HTTP tracing features described in the Go blog: https://go.dev/blog/http-tracing
