### PR TITLE
add context support to GetClient

### DIFF
--- a/api/authlete_api.go
+++ b/api/authlete_api.go
@@ -16,7 +16,11 @@
 
 package api
 
-import "github.com/authlete/authlete-go/dto"
+import (
+	"context"
+
+	"github.com/authlete/authlete-go/dto"
+)
 
 type AuthleteApi interface {
 	Settings() *Settings
@@ -49,6 +53,7 @@ type AuthleteApi interface {
 	DynamicClientDelete(request *dto.ClientRegistrationRequest) (*dto.ClientRegistrationResponse, *AuthleteError)
 	DeleteClient(clientIdentifier interface{}) *AuthleteError
 	GetClient(clientIdentifier interface{}) (*dto.Client, *AuthleteError)
+	GetClientContext(ctx context.Context, clientIdentifier interface{}) (*dto.Client, *AuthleteError)
 	GetClientList(developer string, start uint32, end uint32) (*dto.ClientListResponse, *AuthleteError)
 	UpdateClient(client *dto.Client) (*dto.Client, *AuthleteError)
 	GetRequestableScopes(clientIdentifier interface{}) ([]string, *AuthleteError)


### PR DESCRIPTION
I would like to submit a pull request for athlete-go. This change enables the propagation of context, allowing traces to be associated with their parent spans.

To maintain backward compatibility, I have retained the existing GetClient function while introducing a new GetClientContext function. This approach ensures that current implementations remain unaffected while providing the option to utilize context propagation in new or updated code.

The addition of context propagation enhances the tracing capabilities of the library, allowing for more comprehensive and interconnected trace data.

I would greatly appreciate your review and consideration of this enhancement. Please let me know if you have any questions or if there are any aspects you'd like me to clarify or modify.

Thank you for your time and attention to this pull request.

![trace sample](https://github.com/user-attachments/assets/4af8ba81-9788-4740-af54-62ef7bb71e2f)